### PR TITLE
fix subtraction support error

### DIFF
--- a/torchgeometry/core/conversions.py
+++ b/torchgeometry/core/conversions.py
@@ -299,9 +299,9 @@ def rotation_matrix_to_quaternion(rotation_matrix, eps=1e-6):
     t3_rep = t3.repeat(4, 1).t()
 
     mask_c0 = mask_d2 * mask_d0_d1
-    mask_c1 = mask_d2 * (1 - mask_d0_d1)
-    mask_c2 = (1 - mask_d2) * mask_d0_nd1
-    mask_c3 = (1 - mask_d2) * (1 - mask_d0_nd1)
+    mask_c1 = mask_d2 * ~mask_d0_d1
+    mask_c2 = ~mask_d2 * mask_d0_nd1
+    mask_c3 = ~mask_d2 * ~mask_d0_nd1
     mask_c0 = mask_c0.view(-1, 1).type_as(q0)
     mask_c1 = mask_c1.view(-1, 1).type_as(q1)
     mask_c2 = mask_c2.view(-1, 1).type_as(q2)


### PR DESCRIPTION
This solves the unsupported subtraction error, as written below.

RuntimeError: Subtraction, the `-` operator, with a bool tensor is not supported. If you are trying to invert a mask, use the `~` or `logical_not()` operator instead.

This fix is basically the same as the previous pull request [link](https://github.com/eglxiang/torchgeometry/pull/1), but without bracket.